### PR TITLE
Make the node scripts work on windows

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -12,7 +12,11 @@ exports.MAX_PER_PAGE = 100;
 // Default network id to use when not specified
 exports.NETWORK_ID = 1;
 // An array of fee recipients
-exports.FEE_RECIPIENTS = ['0x0000000000000000000000000000000000000000'];
+exports.FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
+// A flat fee in ZRX that should be charged to the order maker
+exports.MAKER_FEE_ZRX_UNIT_AMOUNT = new _0x_js_1.BigNumber(0);
+// A flat fee in ZRX that should be charged to the order taker
+exports.TAKER_FEE_ZRX_UNIT_AMOUNT = new _0x_js_1.BigNumber(0);
 // Tradable asset pairs
 exports.ASSET_PAIRS = [
     {

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,3 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+exports.ZRX_DECIMALS = 18;
+exports.DEFAULT_PAGE = 0;
+exports.DEFAULT_PER_PAGE = 20;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "scripts": {
         "prettier": "yarn prettier:js && yarn prettier:ts",
-        "build": "yarn build:ts && rm -rf js && cp -r ts/lib/ js",
+        "build": "yarn build:ts && shx rm -rf js && shx cp -r ts/lib/ js",
         "prettier:js": "prettier --write 'js/**/*.js' --config .prettierrc",
         "start:js": "node js/index.js",
         "build:ts": "tsc -p ts/tsconfig.json",
@@ -22,6 +22,7 @@
         "@types/lodash": "^4.14.116",
         "@types/web3-provider-engine": "^14.0.0",
         "prettier": "^1.14.3",
+        "shx": "^0.3.2",
         "tslint": "^5.11.0",
         "typescript": "^3.0.3"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,6 +2466,10 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -3400,7 +3404,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -3678,6 +3682,10 @@ inherits@=2.0.1:
 ini@1.x.x, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+interpret@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -5267,6 +5275,12 @@ readdirp@^2.0.0:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 reflect-metadata@^0.1.10, reflect-metadata@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.12.tgz#311bf0c6b63cd782f228a81abe146a2bfa9c56f2"
@@ -5377,7 +5391,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.3.2:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -5638,12 +5652,28 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shelljs@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shush@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shush/-/shush-1.0.0.tgz#c27415a9e458f2fed39b27cf8eb37c003782b431"
   dependencies:
     caller "~0.0.1"
     strip-json-comments "~0.1.1"
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
This PR makes the build script work on windows. Other scripts use tools that are already OS-agnostic as tsc and tslint.

P.S. Also adds the forgotten JS file changes.