### PR TITLE
Return unique asset pairs

### DIFF
--- a/js/orderbook.js
+++ b/js/orderbook.js
@@ -103,7 +103,8 @@ exports.orderBook = {
                 assetPair.assetDataA.assetData === assetData || assetPair.assetDataB.assetData === assetData;
             nonPaginatedFilteredAssetPairs = assetPairsItems.filter(containsAssetData);
         }
-        const paginatedFilteredAssetPairs = paginator_1.paginate(nonPaginatedFilteredAssetPairs, page, perPage);
+        const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual.bind(_));
+        const paginatedFilteredAssetPairs = paginator_1.paginate(uniqueNonPaginatedFilteredAssetPairs, page, perPage);
         return paginatedFilteredAssetPairs;
     },
     getOrderBookAsync: async (page, perPage, baseAssetData, quoteAssetData) => {

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -119,7 +119,8 @@ export const orderBook = {
                 assetPair.assetDataA.assetData === assetData || assetPair.assetDataB.assetData === assetData;
             nonPaginatedFilteredAssetPairs = assetPairsItems.filter(containsAssetData);
         }
-        const paginatedFilteredAssetPairs = paginate(nonPaginatedFilteredAssetPairs, page, perPage);
+        const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual);
+        const paginatedFilteredAssetPairs = paginate(uniqueNonPaginatedFilteredAssetPairs, page, perPage);
         return paginatedFilteredAssetPairs;
     },
     getOrderBookAsync: async (

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -119,7 +119,7 @@ export const orderBook = {
                 assetPair.assetDataA.assetData === assetData || assetPair.assetDataB.assetData === assetData;
             nonPaginatedFilteredAssetPairs = assetPairsItems.filter(containsAssetData);
         }
-        const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual);
+        const uniqueNonPaginatedFilteredAssetPairs = _.uniqWith(nonPaginatedFilteredAssetPairs, _.isEqual.bind(_));
         const paginatedFilteredAssetPairs = paginate(uniqueNonPaginatedFilteredAssetPairs, page, perPage);
         return paginatedFilteredAssetPairs;
     },


### PR DESCRIPTION
Previously the `asset_pairs` endpoint would return 1 asset pair per order. I.e 100 ZRX/WETH orders returned 100 duplicated `asset_pairs`. 

This confused 0x instant and resulted in duplicate listing in the token selector. 0x instant now supports de-duping but we should de-dupe before returning in Launch Kit.