### PR TITLE
Add CORS for pre-flight requests. Update MAX_PER_PAGE to 1000

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -8,7 +8,7 @@ exports.ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no
 // Frequency of checks for permanently expired orders
 exports.PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Max number of entities per page
-exports.MAX_PER_PAGE = 100;
+exports.MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
 exports.NETWORK_ID = 42;
 // An array of fee recipients

--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 require('@babel/polyfill');
 const bodyParser = require('body-parser');
+const cors = require('cors');
 const express = require('express');
 const asyncHandler = require('express-async-handler');
 require('reflect-metadata');
@@ -14,6 +15,7 @@ const utils_1 = require('./utils');
 (async () => {
     await db_connection_1.initDBConnectionAsync();
     const app = express();
+    app.use(cors());
     app.use(bodyParser.json());
     app.use(url_params_parsing_1.urlParamsParsing);
     /**

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     },
     "devDependencies": {
         "@0x/tslint-config": "^1.0.10",
+        "@types/cors": "^2.8.4",
         "@types/express": "^4.16.0",
         "@types/lodash": "^4.14.116",
         "@types/web3-provider-engine": "^14.0.0",
@@ -39,6 +40,7 @@
         "@0x/web3-wrapper": "^3.1.4",
         "@babel/polyfill": "^7.0.0",
         "body-parser": "^1.18.3",
+        "cors": "^2.8.5",
         "express": "^4.16.3",
         "express-async-handler": "^1.1.4",
         "forever": "^0.15.3",

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -8,7 +8,7 @@ export const ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line cust
 // Frequency of checks for permanently expired orders
 export const PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Max number of entities per page
-export const MAX_PER_PAGE = 100;
+export const MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
 export const NETWORK_ID = 42;
 // An array of fee recipients

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,5 +1,6 @@
 import '@babel/polyfill';
 import * as bodyParser from 'body-parser';
+import * as cors from 'cors';
 import * as express from 'express';
 import * as asyncHandler from 'express-async-handler';
 import 'reflect-metadata';
@@ -14,6 +15,7 @@ import { utils } from './utils';
 (async () => {
     await initDBConnectionAsync();
     const app = express();
+    app.use(cors());
     app.use(bodyParser.json());
     app.use(urlParamsParsing);
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,6 +514,12 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cors@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.4.tgz#50991a759a29c0b89492751008c6af7a7c8267b0"
+  dependencies:
+    "@types/express" "*"
+
 "@types/eth-lightwallet@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/eth-lightwallet/-/eth-lightwallet-3.0.0.tgz#9be5b59dc6fb3fcdb01e65c2c2a79cd601f72dd4"
@@ -538,7 +544,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.16.0":
+"@types/express@*", "@types/express@^4.16.0":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
   dependencies:
@@ -652,10 +658,6 @@ accepts@~1.3.5:
 aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-
-aes-js@^0.2.3:
-  version "0.2.4"
-  resolved "http://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz#94b881ab717286d015fa219e08fb66709dda5a3d"
 
 aes-js@^3.1.1:
   version "3.1.2"
@@ -794,7 +796,7 @@ async-eventemitter@^0.2.2:
   dependencies:
     async "^2.4.0"
 
-"async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c":
+async-eventemitter@ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c:
   version "0.2.3"
   resolved "https://codeload.github.com/ahultgren/async-eventemitter/tar.gz/fa06e39e56786ba541c180061dbf2c0a5bbf951c"
   dependencies:
@@ -1313,10 +1315,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base-x@^1.1.0:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz#42d3d717474f9ea02207f6d1aa1f426913eeb7ac"
-
 base-x@^3.0.2:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.5.tgz#d3ada59afed05b921ab581ec3112e6444ba0795a"
@@ -1584,19 +1582,6 @@ bs58@=4.0.1, bs58@^4.0.0:
 bs58@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-2.0.1.tgz#55908d58f1982aba2008fa1bed8f91998a29bf8d"
-
-bs58@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-3.1.0.tgz#d4c26388bf4804cac714141b1945aa47e5eb248e"
-  dependencies:
-    base-x "^1.1.0"
-
-bs58check@^1.0.8:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-1.3.4.tgz#c52540073749117714fa042c3047eb8f9151cbf8"
-  dependencies:
-    bs58 "^3.1.0"
-    create-hash "^1.1.0"
 
 bs58check@^2.1.2:
   version "2.1.2"
@@ -1964,7 +1949,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cors@^2.8.1:
+cors@^2.8.1, cors@^2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
   dependencies:
@@ -2657,7 +2642,7 @@ ethereumjs-util@5.2.0, ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumj
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
 
-ethereumjs-util@^4.0.1, ethereumjs-util@^4.3.0, ethereumjs-util@^4.4.0:
+ethereumjs-util@^4.0.1, ethereumjs-util@^4.3.0:
   version "4.5.0"
   resolved "http://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz#3e9428b317eebda3d7260d854fddda954b1f1bc6"
   dependencies:
@@ -2715,19 +2700,7 @@ ethereumjs-vm@2.4.0, ethereumjs-vm@^2.0.2, ethereumjs-vm@^2.1.0, ethereumjs-vm@^
     rustbn.js "~0.2.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-wallet@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz#82763b1697ee7a796be7155da9dfb49b2f98cfdb"
-  dependencies:
-    aes-js "^0.2.3"
-    bs58check "^1.0.8"
-    ethereumjs-util "^4.4.0"
-    hdkey "^0.7.0"
-    scrypt.js "^0.2.0"
-    utf8 "^2.1.1"
-    uuid "^2.0.1"
-
-ethereumjs-wallet@0.6.2:
+ethereumjs-wallet@0.6.2, ethereumjs-wallet@~0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ethereumjs-wallet/-/ethereumjs-wallet-0.6.2.tgz#67244b6af3e8113b53d709124b25477b64aeccda"
   dependencies:
@@ -3202,7 +3175,7 @@ ganache-core@0xProject/ganache-core#monorepo-dep:
     ethereumjs-tx "0xProject/ethereumjs-tx#fake-tx-include-signature-by-default"
     ethereumjs-util "^5.2.0"
     ethereumjs-vm "2.3.5"
-    ethereumjs-wallet "0.6.0"
+    ethereumjs-wallet "~0.6.0"
     fake-merkle-patricia-tree "~1.0.1"
     heap "~0.2.6"
     js-scrypt "^0.2.0"
@@ -3460,7 +3433,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hdkey@^0.7.0, hdkey@^0.7.1:
+hdkey@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-0.7.1.tgz#caee4be81aa77921e909b8d228dd0f29acaee632"
   dependencies:
@@ -6407,10 +6380,6 @@ uuid@2.0.1:
 uuid@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"


### PR DESCRIPTION
0x instant in the browser attempts some pre-flight CORS checks which are not supported in 0x Launch Kit.

Instant also by default attempts to query 1000 items at a time, so raise the MAX_PER_PAGE to 1000 to be in-line with Instant. 

I'm not 100% sure if this `MAX_PER_PAGE` is treated like a recommendation and the server is allowed to send less. Right now we return a validation error. 

For now I think we support what Instant supports out of the box (for go live) and can ratchet this in in a follow up PR.