### PR TITLE
Allow some config to be set in ENV

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -12,13 +12,19 @@ exports.PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line custom
 // Max number of entities per page
 exports.MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
-exports.NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? parseInt(process.env.NETWORK_ID, 10) : 42;
-// An array of fee recipients
-exports.FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
+exports.NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? _.parseInt(process.env.NETWORK_ID) : 42;
+// The fee recipient for orders
+exports.FEE_RECIPIENT = !_.isUndefined(process.env.FEE_RECIPIENT)
+    ? process.env.FEE_RECIPIENT
+    : '0x0000000000000000000000000000000000000000';
 // A flat fee in ZRX that should be charged to the order maker
-exports.MAKER_FEE_ZRX_UNIT_AMOUNT = new _0x_js_1.BigNumber(0);
+exports.MAKER_FEE_ZRX_UNIT_AMOUNT = !_.isUndefined(process.env.MAKER_FEE_ZRX_UNIT_AMOUNT)
+    ? new _0x_js_1.BigNumber(process.env.MAKER_FEE_ZRX_UNIT_AMOUNT)
+    : new _0x_js_1.BigNumber(0);
 // A flat fee in ZRX that should be charged to the order taker
-exports.TAKER_FEE_ZRX_UNIT_AMOUNT = new _0x_js_1.BigNumber(0);
+exports.TAKER_FEE_ZRX_UNIT_AMOUNT = !_.isUndefined(process.env.TAKER_FEE_ZRX_UNIT_AMOUNT)
+    ? new _0x_js_1.BigNumber(process.env.TAKER_FEE_ZRX_UNIT_AMOUNT)
+    : new _0x_js_1.BigNumber(0);
 // Whitelisted token addresses. Set to a '*' instead of an array to allow all tokens.
 exports.WHITELISTED_TOKENS = [
     '0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa',

--- a/js/config.js
+++ b/js/config.js
@@ -1,8 +1,10 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
+// tslint:disable:custom-no-magic-numbers
 const _0x_js_1 = require('0x.js');
+const _ = require('lodash');
 // Network port to listen on
-exports.HTTP_PORT = 3000;
+exports.HTTP_PORT = process.env.HTTP_PORT || 3000;
 // A time window after which the order is considered permanently expired
 exports.ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders
@@ -10,7 +12,7 @@ exports.PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line custom
 // Max number of entities per page
 exports.MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
-exports.NETWORK_ID = 42;
+exports.NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? parseInt(process.env.NETWORK_ID, 10) : 42;
 // An array of fee recipients
 exports.FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
 // A flat fee in ZRX that should be charged to the order maker
@@ -23,6 +25,6 @@ exports.WHITELISTED_TOKENS = [
     '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
 ];
 // Ethereum RPC url
-exports.RPC_URL = 'https://kovan.infura.io/v3';
+exports.RPC_URL = process.env.RPC_URL || 'https://kovan.infura.io/v3';
 // Default ERC20 token precision
 exports.DEFAULT_ERC20_TOKEN_PRECISION = 18;

--- a/js/config.js
+++ b/js/config.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 const _0x_js_1 = require('0x.js');
 const _ = require('lodash');
 // Network port to listen on
-exports.HTTP_PORT = process.env.HTTP_PORT || 3000;
+exports.HTTP_PORT = !_.isUndefined(process.env.HTTP_PORT) ? process.env.HTTP_PORT : 3000;
 // A time window after which the order is considered permanently expired
 exports.ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders
@@ -31,6 +31,6 @@ exports.WHITELISTED_TOKENS = [
     '0xd0a1e359811322d97991e03f863a0c30c2cf029c',
 ];
 // Ethereum RPC url
-exports.RPC_URL = process.env.RPC_URL || 'https://kovan.infura.io/v3';
+exports.RPC_URL = !_.isUndefined(process.env.RPC_URL) ? process.env.RPC_URL : 'https://kovan.infura.io/v3';
 // Default ERC20 token precision
 exports.DEFAULT_ERC20_TOKEN_PRECISION = 18;

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '0x.js';
 import * as _ from 'lodash';
 
 // Network port to listen on
-export const HTTP_PORT = process.env.HTTP_PORT || 3000;
+export const HTTP_PORT = !_.isUndefined(process.env.HTTP_PORT) ? process.env.HTTP_PORT : 3000;
 // A time window after which the order is considered permanently expired
 export const ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders
@@ -30,6 +30,6 @@ export const WHITELISTED_TOKENS: string[] | '*' = [
     '0xd0a1e359811322d97991e03f863a0c30c2cf029c', // WETH
 ];
 // Ethereum RPC url
-export const RPC_URL = process.env.RPC_URL || 'https://kovan.infura.io/v3';
+export const RPC_URL = !_.isUndefined(process.env.RPC_URL) ? process.env.RPC_URL : 'https://kovan.infura.io/v3';
 // Default ERC20 token precision
 export const DEFAULT_ERC20_TOKEN_PRECISION = 18;

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -1,8 +1,9 @@
+// tslint:disable:custom-no-magic-numbers
 import { BigNumber } from '0x.js';
 import * as _ from 'lodash';
 
 // Network port to listen on
-export const HTTP_PORT = 3000;
+export const HTTP_PORT = process.env.HTTP_PORT || 3000;
 // A time window after which the order is considered permanently expired
 export const ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders
@@ -10,7 +11,7 @@ export const PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line c
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
-export const NETWORK_ID = 42;
+export const NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? parseInt(process.env.NETWORK_ID, 10) : 42;
 // An array of fee recipients
 export const FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
 // A flat fee in ZRX that should be charged to the order maker
@@ -23,6 +24,6 @@ export const WHITELISTED_TOKENS: string[] | '*' = [
     '0xd0a1e359811322d97991e03f863a0c30c2cf029c', // WETH
 ];
 // Ethereum RPC url
-export const RPC_URL = 'https://kovan.infura.io/v3';
+export const RPC_URL = process.env.RPC_URL || 'https://kovan.infura.io/v3';
 // Default ERC20 token precision
 export const DEFAULT_ERC20_TOKEN_PRECISION = 18;

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -11,7 +11,7 @@ export const PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line c
 // Max number of entities per page
 export const MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
-export const NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? parseInt(process.env.NETWORK_ID, 10) : 42;
+export const NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? _.parseInt(process.env.NETWORK_ID) : 42;
 // An array of fee recipients
 export const FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
 // A flat fee in ZRX that should be charged to the order maker

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -12,12 +12,18 @@ export const PERMANENT_CLEANUP_INTERVAL_MS = 10 * 1000; // tslint:disable-line c
 export const MAX_PER_PAGE = 1000;
 // Default network id to use when not specified
 export const NETWORK_ID = !_.isUndefined(process.env.NETWORK_ID) ? _.parseInt(process.env.NETWORK_ID) : 42;
-// An array of fee recipients
-export const FEE_RECIPIENT = '0x0000000000000000000000000000000000000000';
+// The fee recipient for orders
+export const FEE_RECIPIENT = !_.isUndefined(process.env.FEE_RECIPIENT)
+    ? process.env.FEE_RECIPIENT
+    : '0x0000000000000000000000000000000000000000';
 // A flat fee in ZRX that should be charged to the order maker
-export const MAKER_FEE_ZRX_UNIT_AMOUNT = new BigNumber(0);
+export const MAKER_FEE_ZRX_UNIT_AMOUNT = !_.isUndefined(process.env.MAKER_FEE_ZRX_UNIT_AMOUNT)
+    ? new BigNumber(process.env.MAKER_FEE_ZRX_UNIT_AMOUNT)
+    : new BigNumber(0);
 // A flat fee in ZRX that should be charged to the order taker
-export const TAKER_FEE_ZRX_UNIT_AMOUNT = new BigNumber(0);
+export const TAKER_FEE_ZRX_UNIT_AMOUNT = !_.isUndefined(process.env.TAKER_FEE_ZRX_UNIT_AMOUNT)
+    ? new BigNumber(process.env.TAKER_FEE_ZRX_UNIT_AMOUNT)
+    : new BigNumber(0);
 // Whitelisted token addresses. Set to a '*' instead of an array to allow all tokens.
 export const WHITELISTED_TOKENS: string[] | '*' = [
     '0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa', // ZRX


### PR DESCRIPTION
#14 
```
RPC_URL=http://localhost:8545 NETWORK_ID=50 HTTP_PORT=4000 yarn start:ts
```

Exposing some common config items to be set in ENV vars.

Thoughts on `WHITELISTED_TOKENS` so it can quickly be spun up on multiple networks without rebuilding? Might require a bit of parsing to sort out '*' versus an csv tokens.
