### PR TITLE
Return SRA compliant get order result

### DIFF
--- a/js/orderbook.js
+++ b/js/orderbook.js
@@ -199,7 +199,8 @@ exports.orderBook = {
         if (_.isUndefined(signedOrderModelIfExists)) {
             return undefined;
         } else {
-            return deserializeOrder(signedOrderModelIfExists);
+            const deserializedOrder = deserializeOrder(signedOrderModelIfExists);
+            return { metaData: {}, order: deserializedOrder };
         }
     },
 };

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -215,13 +215,14 @@ export const orderBook = {
         const paginatedApiOrders = paginate(apiOrders, page, perPage);
         return paginatedApiOrders;
     },
-    getOrderByHashIfExistsAsync: async (orderHash: string): Promise<SignedOrder | undefined> => {
+    getOrderByHashIfExistsAsync: async (orderHash: string): Promise<APIOrder | undefined> => {
         const connection = getDBConnection();
         const signedOrderModelIfExists = await connection.manager.findOne(SignedOrderModel, orderHash);
         if (_.isUndefined(signedOrderModelIfExists)) {
             return undefined;
         } else {
-            return deserializeOrder(signedOrderModelIfExists as Required<SignedOrderModel>);
+            const deserializedOrder = deserializeOrder(signedOrderModelIfExists as Required<SignedOrderModel>);
+            return { metaData: {}, order: deserializedOrder };
         }
     },
 };


### PR DESCRIPTION
Return an `APIOrder` when calling `getOrderByHashIfExistsAsync`.

fixes #29.

[0x Connect](https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_order_schema.json) and the SRA Spec require `order` and `metaData` fields to be present on the responses.