### PR TITLE
Normalize fee recipient for JSON schema validation

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -46,8 +46,8 @@ exports.handlers = {
     feeRecipients: (req, res) => {
         const { page, perPage } = parsePaginationConfig(req);
         const normalizedFeeRecipient = config_1.FEE_RECIPIENT.toLowerCase();
-        const FEE_RECIPIENTS = [normalizedFeeRecipient];
-        const paginatedFeeRecipients = paginator_1.paginate(FEE_RECIPIENTS, page, perPage);
+        const feeRecipients = [normalizedFeeRecipient];
+        const paginatedFeeRecipients = paginator_1.paginate(feeRecipients, page, perPage);
         res.status(HttpStatus.OK).send(paginatedFeeRecipients);
     },
     orderbookAsync: async (req, res) => {

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -45,7 +45,8 @@ exports.handlers = {
     },
     feeRecipients: (req, res) => {
         const { page, perPage } = parsePaginationConfig(req);
-        const FEE_RECIPIENTS = [config_1.FEE_RECIPIENT];
+        const normalizedFeeRecipient = config_1.FEE_RECIPIENT.toLowerCase();
+        const FEE_RECIPIENTS = [normalizedFeeRecipient];
         const paginatedFeeRecipients = paginator_1.paginate(FEE_RECIPIENTS, page, perPage);
         res.status(HttpStatus.OK).send(paginatedFeeRecipients);
     },
@@ -64,9 +65,10 @@ exports.handlers = {
     },
     orderConfig: (req, res) => {
         utils_1.utils.validateSchema(req.body, json_schemas_1.schemas.orderConfigRequestSchema);
+        const normalizedFeeRecipient = config_1.FEE_RECIPIENT.toLowerCase();
         const orderConfigResponse = {
             senderAddress: constants_1.NULL_ADDRESS,
-            feeRecipientAddress: config_1.FEE_RECIPIENT,
+            feeRecipientAddress: normalizedFeeRecipient,
             makerFee: web3_wrapper_1.Web3Wrapper.toBaseUnitAmount(
                 config_1.MAKER_FEE_ZRX_UNIT_AMOUNT,
                 constants_1.ZRX_DECIMALS,

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -53,7 +53,8 @@ export const handlers = {
     },
     feeRecipients: (req: express.Request, res: express.Response) => {
         const { page, perPage } = parsePaginationConfig(req);
-        const FEE_RECIPIENTS = [FEE_RECIPIENT];
+        const normalizedFeeRecipient = FEE_RECIPIENT.toLowerCase();
+        const FEE_RECIPIENTS = [normalizedFeeRecipient];
         const paginatedFeeRecipients = paginate(FEE_RECIPIENTS, page, perPage);
         res.status(HttpStatus.OK).send(paginatedFeeRecipients);
     },
@@ -67,9 +68,10 @@ export const handlers = {
     },
     orderConfig: (req: express.Request, res: express.Response) => {
         utils.validateSchema(req.body, schemas.orderConfigRequestSchema);
+        const normalizedFeeRecipient = FEE_RECIPIENT.toLowerCase();
         const orderConfigResponse = {
             senderAddress: NULL_ADDRESS,
-            feeRecipientAddress: FEE_RECIPIENT,
+            feeRecipientAddress: normalizedFeeRecipient,
             makerFee: Web3Wrapper.toBaseUnitAmount(MAKER_FEE_ZRX_UNIT_AMOUNT, ZRX_DECIMALS).toString(),
             takerFee: Web3Wrapper.toBaseUnitAmount(TAKER_FEE_ZRX_UNIT_AMOUNT, ZRX_DECIMALS).toString(),
         };

--- a/ts/src/handlers.ts
+++ b/ts/src/handlers.ts
@@ -54,8 +54,8 @@ export const handlers = {
     feeRecipients: (req: express.Request, res: express.Response) => {
         const { page, perPage } = parsePaginationConfig(req);
         const normalizedFeeRecipient = FEE_RECIPIENT.toLowerCase();
-        const FEE_RECIPIENTS = [normalizedFeeRecipient];
-        const paginatedFeeRecipients = paginate(FEE_RECIPIENTS, page, perPage);
+        const feeRecipients = [normalizedFeeRecipient];
+        const paginatedFeeRecipients = paginate(feeRecipients, page, perPage);
         res.status(HttpStatus.OK).send(paginatedFeeRecipients);
     },
     orderbookAsync: async (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
Our JSON schemas expect all addresses to be non-checksummed addresses. 

fixes #33 