### PR TITLE
Ganache core optional dependency is required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN yarn --frozen-lockfile --ignore-optional
+RUN yarn --frozen-lockfile
 RUN yarn global add forever
 
 # Bundle app source


### PR DESCRIPTION
trufflesuite/ganache-core#297

`--skip-optional` will ignore the optional dependencies and not install them. It appears that ganache-core requires the `scrypt.js` dependency via `ethereumjs-wallet`, which is being skipped.

This results in a failure on load.

```
Error: Cannot find module 'scrypt.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:587:15)
    at Function.Module._load (internal/modules/cjs/loader.js:513:25)
    at Module.require (internal/modules/cjs/loader.js:643:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/external "scrypt.js":1:1)
    at n (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/webpack/bootstrap:19:1)
    at Object.<anonymous> (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/node_modules/ethereumjs-wallet/index.js:8:16)
    at n (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/webpack/bootstrap:19:1)
    at Object.<anonymous> (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/lib/statemanager.js:8:14)
    at n (/usr/src/app/node_modules/ganache-core/build/webpack:/Ganache/webpack/bootstrap:19:1)
error: Forever detected script exited with code: 1
```

Removing the skip optional for now will be a bandaid fix, but results in additional output that looks like error (usb/node-hid failures but these are truly optional unless using LedgerSubprovider).

