### PR TITLE
Correcting isNegative function call in assertEnvVarType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Webstorm config folder
+.idea
+
 # dotenv environment variables file
 .env
 

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -85,7 +85,7 @@ function assertEnvVarType(name: string, value: any, expectedType: EnvVarType): a
         case EnvVarType.UnitAmount:
             try {
                 returnValue = new BigNumber(parseFloat(value));
-                if (returnValue.isNegative) {
+                if (returnValue.isNegative()) {
                     throw new Error();
                 }
             } catch (err) {


### PR DESCRIPTION
In config.ts, when passing EnvVarType.UnitAmount to assertEnvVarType, returnValue.isNegative is not called because the parentheses are missing.