### PR TITLE
(Fix) - Sort orderbook by price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 CHANGELOG
 
+## v0.1.0 - _March 27, 2019_
+
+    * Add the sorting of bids/asks for the GET /v2/orderbook endpoint as stated in the SRA v2:
+      https://github.com/0xProject/standard-relayer-api/blob/master/http/v2.md#get-v2orderbook
+
 ## v0.0.2 - _February 5, 2019_
 
     * Fix bug where orders in DB weren't being added to OrderWatcher on re-start

--- a/js/orderbook.js
+++ b/js/orderbook.js
@@ -147,10 +147,12 @@ class OrderBook {
         const bidApiOrders = bidSignedOrderModels
             .map(deserializeOrder)
             .filter(order => !this._shadowedOrders.has(_0x_js_1.orderHashUtils.getOrderHashHex(order)))
+            .sort((orderA, orderB) => compareBidOrder(orderA, orderB))
             .map(signedOrder => ({ metaData: {}, order: signedOrder }));
         const askApiOrders = askSignedOrderModels
             .map(deserializeOrder)
             .filter(order => !this._shadowedOrders.has(_0x_js_1.orderHashUtils.getOrderHashHex(order)))
+            .sort((orderA, orderB) => compareAskOrder(orderA, orderB))
             .map(signedOrder => ({ metaData: {}, order: signedOrder }));
         const paginatedBidApiOrders = paginator_1.paginate(bidApiOrders, page, perPage);
         const paginatedAskApiOrders = paginator_1.paginate(askApiOrders, page, perPage);
@@ -233,6 +235,30 @@ class OrderBook {
     }
 }
 exports.OrderBook = OrderBook;
+const compareAskOrder = (orderA, orderB) => {
+    const orderAPrice = orderA.takerAssetAmount.div(orderA.makerAssetAmount);
+    const orderBPrice = orderB.takerAssetAmount.div(orderB.makerAssetAmount);
+    if (!orderAPrice.isEqualTo(orderBPrice)) {
+        return orderAPrice.comparedTo(orderBPrice);
+    }
+    return compareOrder(orderA, orderB);
+};
+const compareBidOrder = (orderA, orderB) => {
+    const orderAPrice = orderA.makerAssetAmount.div(orderA.takerAssetAmount);
+    const orderBPrice = orderB.makerAssetAmount.div(orderB.takerAssetAmount);
+    if (!orderAPrice.isEqualTo(orderBPrice)) {
+        return orderBPrice.comparedTo(orderAPrice);
+    }
+    return compareOrder(orderA, orderB);
+};
+const compareOrder = (orderA, orderB) => {
+    const orderAFeePrice = orderA.takerFee.div(orderA.takerAssetAmount);
+    const orderBFeePrice = orderB.takerFee.div(orderB.takerAssetAmount);
+    if (!orderAFeePrice.isEqualTo(orderBFeePrice)) {
+        return orderBFeePrice.comparedTo(orderAFeePrice);
+    }
+    return orderA.expirationTimeSeconds.comparedTo(orderB.expirationTimeSeconds);
+};
 const includesTokenAddress = (assetData, tokenAddress) => {
     const decodedAssetData = _0x_js_1.assetDataUtils.decodeAssetDataOrThrow(assetData);
     if (_0x_js_1.assetDataUtils.isMultiAssetData(decodedAssetData)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "0x-launch-kit",
-    "version": "0.0.2",
+    "version": "0.1.0",
     "description": "Template 0x relayer",
     "repository": "git@github.com:0xProject/0x-launch-kit.git",
     "author": "Leonid Logvinov <logvinov.leon@gmail.com>",

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -278,7 +278,7 @@ const compareAskOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
         return orderAPrice.comparedTo(orderBPrice);
     }
 
-    return compareOrder(orderA, orderB);
+    return compareOrderByFeeRatio(orderA, orderB);
 };
 
 const compareBidOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
@@ -288,10 +288,10 @@ const compareBidOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
         return orderBPrice.comparedTo(orderAPrice);
     }
 
-    return compareOrder(orderA, orderB);
+    return compareOrderByFeeRatio(orderA, orderB);
 };
 
-const compareOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
+const compareOrderByFeeRatio = (orderA: SignedOrder, orderB: SignedOrder): number => {
     const orderAFeePrice = orderA.takerFee.div(orderA.takerAssetAmount);
     const orderBFeePrice = orderB.takerFee.div(orderB.takerAssetAmount);
     if (!orderAFeePrice.isEqualTo(orderBFeePrice)) {

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -177,10 +177,12 @@ export class OrderBook {
         const bidApiOrders: APIOrder[] = bidSignedOrderModels
             .map(deserializeOrder)
             .filter(order => !this._shadowedOrders.has(orderHashUtils.getOrderHashHex(order)))
+            .sort((orderA, orderB) => compareBidOrder(orderA, orderB))
             .map(signedOrder => ({ metaData: {}, order: signedOrder }));
         const askApiOrders: APIOrder[] = askSignedOrderModels
             .map(deserializeOrder)
             .filter(order => !this._shadowedOrders.has(orderHashUtils.getOrderHashHex(order)))
+            .sort((orderA, orderB) => compareAskOrder(orderA, orderB))
             .map(signedOrder => ({ metaData: {}, order: signedOrder }));
         const paginatedBidApiOrders = paginate(bidApiOrders, page, perPage);
         const paginatedAskApiOrders = paginate(askApiOrders, page, perPage);
@@ -268,6 +270,36 @@ export class OrderBook {
         }
     }
 }
+
+const compareAskOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
+    const orderAPrice = orderA.takerAssetAmount.div(orderA.makerAssetAmount);
+    const orderBPrice = orderB.takerAssetAmount.div(orderB.makerAssetAmount);
+    if (!orderAPrice.isEqualTo(orderBPrice)) {
+        return orderAPrice.comparedTo(orderBPrice);
+    }
+
+    return compareOrder(orderA, orderB);
+};
+
+const compareBidOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
+    const orderAPrice = orderA.makerAssetAmount.div(orderA.takerAssetAmount);
+    const orderBPrice = orderB.makerAssetAmount.div(orderB.takerAssetAmount);
+    if (!orderAPrice.isEqualTo(orderBPrice)) {
+        return orderBPrice.comparedTo(orderAPrice);
+    }
+
+    return compareOrder(orderA, orderB);
+};
+
+const compareOrder = (orderA: SignedOrder, orderB: SignedOrder): number => {
+    const orderAFeePrice = orderA.takerFee.div(orderA.takerAssetAmount);
+    const orderBFeePrice = orderB.takerFee.div(orderB.takerAssetAmount);
+    if (!orderAFeePrice.isEqualTo(orderBFeePrice)) {
+        return orderBFeePrice.comparedTo(orderAFeePrice);
+    }
+
+    return orderA.expirationTimeSeconds.comparedTo(orderB.expirationTimeSeconds);
+};
 
 const includesTokenAddress = (assetData: string, tokenAddress: string): boolean => {
     const decodedAssetData = assetDataUtils.decodeAssetDataOrThrow(assetData);


### PR DESCRIPTION
Closes #41 

Implements the sorting of bids/asks for the `GET /v2/orderbook` endpoint as stated in the SRA v2:
https://github.com/0xProject/standard-relayer-api/blob/master/http/v2.md#get-v2orderbook

- Sort bids in descending order by price: `makerAssetAmount/takerAssetAmount`.
- Sort asks in ascending order by price: `takerAssetAmount/makerAssetAmount`.
- The orders are further sorted by taker fee price. After taker fee price, orders are to be sorted by expiration in ascending order.