### PR TITLE
Set the simulation taker address to non 0 address

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -45,6 +45,8 @@ exports.TAKER_FEE_ZRX_UNIT_AMOUNT = _.isEmpty(process.env.TAKER_FEE_ZRX_UNIT_AMO
 exports.RPC_URL = _.isEmpty(process.env.RPC_URL)
     ? 'https://kovan.infura.io/v3/e2c067d9717e492091d1f1d7a2ec55aa'
     : assertEnvVarType('RPC_URL', process.env.RPC_URL, EnvVarType.Url);
+// Address used when simulating transfers from the maker to the simulation address
+exports.DEFAULT_TAKER_SIMULATION_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 // A time window after which the order is considered permanently expired
 exports.ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders

--- a/js/orderbook.js
+++ b/js/orderbook.js
@@ -131,7 +131,11 @@ class OrderBook {
     }
     async addOrderAsync(signedOrder) {
         const connection = db_connection_1.getDBConnection();
-        await this._contractWrappers.exchange.validateOrderFillableOrThrowAsync(signedOrder);
+        // Validate transfers to this fee recipient address. Some tokens cannot be transferred to
+        // the null address (default)
+        await this._contractWrappers.exchange.validateOrderFillableOrThrowAsync(signedOrder, {
+            simulationTakerAddress: config_1.FEE_RECIPIENT,
+        });
         await this._orderWatcher.addOrderAsync(signedOrder);
         const signedOrderModel = serializeOrder(signedOrder);
         await connection.manager.save(signedOrderModel);

--- a/js/orderbook.js
+++ b/js/orderbook.js
@@ -131,10 +131,10 @@ class OrderBook {
     }
     async addOrderAsync(signedOrder) {
         const connection = db_connection_1.getDBConnection();
-        // Validate transfers to this fee recipient address. Some tokens cannot be transferred to
+        // Validate transfers to a non 0 default address. Some tokens cannot be transferred to
         // the null address (default)
         await this._contractWrappers.exchange.validateOrderFillableOrThrowAsync(signedOrder, {
-            simulationTakerAddress: config_1.FEE_RECIPIENT,
+            simulationTakerAddress: config_1.DEFAULT_TAKER_SIMULATION_ADDRESS,
         });
         await this._orderWatcher.addOrderAsync(signedOrder);
         const signedOrderModel = serializeOrder(signedOrder);

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -48,7 +48,7 @@ export const RPC_URL = _.isEmpty(process.env.RPC_URL)
     ? 'https://kovan.infura.io/v3/e2c067d9717e492091d1f1d7a2ec55aa'
     : assertEnvVarType('RPC_URL', process.env.RPC_URL, EnvVarType.Url);
 
-// Address used when simulating transfers from the maker to the simulation address
+// Address used when simulating transfers from the maker as part of 0x order validation
 export const DEFAULT_TAKER_SIMULATION_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 // A time window after which the order is considered permanently expired

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -48,6 +48,9 @@ export const RPC_URL = _.isEmpty(process.env.RPC_URL)
     ? 'https://kovan.infura.io/v3/e2c067d9717e492091d1f1d7a2ec55aa'
     : assertEnvVarType('RPC_URL', process.env.RPC_URL, EnvVarType.Url);
 
+// Address used when simulating transfers from the maker to the simulation address
+export const DEFAULT_TAKER_SIMULATION_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 // A time window after which the order is considered permanently expired
 export const ORDER_SHADOWING_MARGIN_MS = 100 * 1000; // tslint:disable-line custom-no-magic-numbers
 // Frequency of checks for permanently expired orders

--- a/ts/src/orderbook.ts
+++ b/ts/src/orderbook.ts
@@ -15,7 +15,7 @@ import * as _ from 'lodash';
 
 import {
     DEFAULT_ERC20_TOKEN_PRECISION,
-    FEE_RECIPIENT,
+    DEFAULT_TAKER_SIMULATION_ADDRESS,
     NETWORK_ID,
     ORDER_SHADOWING_MARGIN_MS,
     PERMANENT_CLEANUP_INTERVAL_MS,
@@ -156,10 +156,10 @@ export class OrderBook {
     }
     public async addOrderAsync(signedOrder: SignedOrder): Promise<void> {
         const connection = getDBConnection();
-        // Validate transfers to this fee recipient address. Some tokens cannot be transferred to
+        // Validate transfers to a non 0 default address. Some tokens cannot be transferred to
         // the null address (default)
         await this._contractWrappers.exchange.validateOrderFillableOrThrowAsync(signedOrder, {
-            simulationTakerAddress: FEE_RECIPIENT,
+            simulationTakerAddress: DEFAULT_TAKER_SIMULATION_ADDRESS,
         });
         await this._orderWatcher.addOrderAsync(signedOrder);
         const signedOrderModel = serializeOrder(signedOrder);


### PR DESCRIPTION
Simulating the transfer from `makerAddress` to `takerAddress` is generally ok. Some tokens have a restriction on transferring to `address(0)`. This restriction does exist in our DummyERC721Token so when orders created with our Dummy tokens are added to Launch Kit they will fail validation.

In the event of a error transferring to `address(0)` the user will see a `TRANSFER_FAILED` error when submitting the order.