### PR TITLE
Optimise Dockerfile for size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,6 @@ typings/
 ts/lib
 
 # sqlite DB
-database.sqlite
+db/database.sqlite
 
 TODO.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-FROM node:11.1.0
-
-# Create app directory
+# Stage 1
+FROM node:11-alpine as yarn-install
 WORKDIR /usr/src/app
-
 # Install app dependencies
-COPY package.json ./
-COPY yarn.lock ./
+COPY package.json yarn.lock ./
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache --virtual build-dependencies bash git openssh python make g++ && \
+    yarn --frozen-lockfile --no-cache && \
+    apk del build-dependencies && \
+    yarn cache clean
 
-RUN yarn --frozen-lockfile
-RUN yarn global add forever
-
+# Runtime container with minimal dependencies
+FROM node:11-alpine
+WORKDIR /usr/src/app
+COPY --from=yarn-install /usr/src/app/node_modules /usr/src/app/node_modules
 # Bundle app source
 COPY . .
 
 RUN yarn build
 
 EXPOSE 3000
-CMD [ "forever", "ts/lib/index.js" ]
+CMD [ "./node_modules/.bin/forever", "ts/lib/index.js" ]

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,6 +1,6 @@
 {
     "type": "sqlite",
-    "database": "database.sqlite",
+    "database": "db/database.sqlite",
     "synchronize": true,
     "logging": true,
     "entities": ["ts/lib/entity/**/*.js", "js/entity/**/*.js"],


### PR DESCRIPTION
### Docker image size
Reduces docker image size from 524mb -> 91mb. 
Download time (assuming 30Mbps) 2m26s -> 25s

### Database location
It's difficult to create a volume and mount it as a file in `docker-compose` so that orders can persist. I.e
```yaml
backend:
  image: 0x-launch-kit-backend
  volume:
    backend:/usr/src/app/database.sqlite
volumes:
  backend
```

Moving the database into a directory helps

```yaml
backend:
  image: 0x-launch-kit-backend
  volume:
    backend:/usr/src/app/db
volumes:
  backend
```


